### PR TITLE
BUGFIX: return nil when there are no files in changeset

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -106,7 +105,9 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(files) == 0 {
-		return fmt.Errorf("no files: %v", files)
+		// return nil since there are valid reasons to run commit without changes `git commit --amend`
+		log.Info("sops: no files in the changeset")
+		return nil
 	}
 
 	confPath, err := getSopsConf(".")


### PR DESCRIPTION
`return nil` when there are no files in changeset to support commands like `git commit --amend`.