### PR TITLE
BUGFIX sops pre-commit, don't fail if no sops.yaml config is found

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ trigger:
   branch: [main]
 steps:
   - name: test
-    image: golangci/golangci-lint:v1.38.0-alpine
+    image: golangci/golangci-lint:v2.5
     volumes:
       - name: cache
         path: /go

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,6 @@ steps:
       - name: cache
         path: /go
     commands:
-      - apk add make
       - make test
     resources:
       requests:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+version: "2"
+linters:
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - '-ST1003'
+        - '-ST1005'
+        - '-ST1016'
+  disable:
+    - testpackage
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```bash
+make test                          # Lint (golangci-lint) + run all tests
+go test -cover ./...               # Tests only, no linting
+go test -cover -run=TestName ./... # Run a single test
+go install ./cmd/sops-precommit/   # Build and install the binary
+```
+
+The `make test` target runs `golangci-lint` first, then `go test`. You can scope both with `PKG=./internal/cli/...` and `RUN=TestDecryptFiles`.
+
+## Architecture
+
+This is a Go CLI tool that validates SOPS encryption in git pre-commit hooks. It accepts a list of changed files (via args or stdin pipe) and attempts to decrypt each one to verify they are properly encrypted.
+
+**Entry point:** `cmd/sops-precommit/main.go` - thin wrapper that calls `cli.NewRootCommand().Execute()`
+
+**Core logic:** `internal/cli/cli.go` - all business logic lives here:
+- `runE` - parses file list from args or stdin, loads `.sops.yaml` config, filters files, decrypts
+- `getFilteredFiles` - if a `.sops.yaml` exists, filters files to only those matching `creation_rules`; otherwise passes all files through
+- `decryptFiles` - validates each file by attempting SOPS decryption; collects all errors before returning
+
+**Key interfaces:** `decrypter` and `sopsRuleMatcher` abstract the SOPS library for testability. Tests use `decryptmock` to avoid real crypto operations.
+
+**Config:** Uses cobra/viper. Log level configurable via `--log-level` flag or `SOPS_LOG_LEVEL` env var.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,13 @@
-# CLAUDE.md
+# AGENTS.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+## Build & Test
 
-## Build & Test Commands
-
-```bash
-make test                          # Lint (golangci-lint) + run all tests
-go test -cover ./...               # Tests only, no linting
-go test -cover -run=TestName ./... # Run a single test
-go install ./cmd/sops-precommit/   # Build and install the binary
-```
-
-The `make test` target runs `golangci-lint` first, then `go test`. You can scope both with `PKG=./internal/cli/...` and `RUN=TestDecryptFiles`.
+Run `make test` to lint and test. See `Makefile` for available targets and variables.
 
 ## Architecture
 
-This is a Go CLI tool that validates SOPS encryption in git pre-commit hooks. It accepts a list of changed files (via args or stdin pipe) and attempts to decrypt each one to verify they are properly encrypted.
+Go CLI tool that validates SOPS encryption in git pre-commit hooks. Accepts changed files via args or stdin, then decrypts each to verify encryption.
 
-**Entry point:** `cmd/sops-precommit/main.go` - thin wrapper that calls `cli.NewRootCommand().Execute()`
-
-**Core logic:** `internal/cli/cli.go` - all business logic lives here:
-- `runE` - parses file list from args or stdin, loads `.sops.yaml` config, filters files, decrypts
-- `getFilteredFiles` - if a `.sops.yaml` exists, filters files to only those matching `creation_rules`; otherwise passes all files through
-- `decryptFiles` - validates each file by attempting SOPS decryption; collects all errors before returning
-
-**Key interfaces:** `decrypter` and `sopsRuleMatcher` abstract the SOPS library for testability. Tests use `decryptmock` to avoid real crypto operations.
-
-**Config:** Uses cobra/viper. Log level configurable via `--log-level` flag or `SOPS_LOG_LEVEL` env var.
+- **Entry point:** `cmd/sops-precommit/main.go` → `cli.NewRootCommand().Execute()`
+- **Core logic:** `internal/cli/cli.go` — if no `.sops.yaml` config exists, exits early with success. Otherwise filters files to those matching `creation_rules` and validates decryption.
+- **Testability:** `decrypter` and `sopsRuleMatcher` interfaces abstract the SOPS library. Tests use `decryptmock`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+Read and follow AGENTS.md in this repository.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kanopy-platform/sops-precommit
 
-go 1.16
+go 1.25
 
 require (
 	github.com/sirupsen/logrus v1.4.2
@@ -8,4 +8,83 @@ require (
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 	go.mozilla.org/sops/v3 v3.7.1
+)
+
+require (
+	cloud.google.com/go v0.93.3 // indirect
+	cloud.google.com/go/storage v1.10.0 // indirect
+	filippo.io/age v1.0.0-beta7 // indirect
+	github.com/Azure/azure-sdk-for-go v31.2.0+incompatible // indirect
+	github.com/Azure/go-autorest/autorest v0.9.0 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.5.0 // indirect
+	github.com/Azure/go-autorest/autorest/azure/auth v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/azure/cli v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/date v0.1.0 // indirect
+	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
+	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
+	github.com/Azure/go-autorest/logger v0.1.0 // indirect
+	github.com/Azure/go-autorest/tracing v0.5.0 // indirect
+	github.com/aws/aws-sdk-go v1.37.18 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/dimchansky/utfbom v1.1.0 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/googleapis/gax-go/v2 v2.1.0 // indirect
+	github.com/goware/prefixer v0.0.0-20160118172347-395022866408 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/go-retryablehttp v0.5.4 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
+	github.com/hashicorp/go-sockaddr v1.0.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/vault/api v1.0.4 // indirect
+	github.com/hashicorp/vault/sdk v0.1.13 // indirect
+	github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
+	github.com/lib/pq v1.2.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mattn/go-colorable v0.1.6 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pierrec/lz4 v2.0.5+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/ryanuber/go-glob v1.0.0 // indirect
+	github.com/sergi/go-diff v1.1.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	go.mozilla.org/gopgagent v0.0.0-20170926210634-4d7ea76ff71a // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420 // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf // indirect
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
+	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
+	google.golang.org/api v0.56.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210828152312-66f60bf46e71 // indirect
+	google.golang.org/grpc v1.40.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/ini.v1 v1.63.2 // indirect
+	gopkg.in/square/go-jose.v2 v2.3.1 // indirect
+	gopkg.in/urfave/cli.v1 v1.20.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,7 +2,7 @@ package cli
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +14,7 @@ import (
 	"go.mozilla.org/sops/v3/decrypt"
 )
 
-var SopsNoConfigMatch = errors.New("error loading config: no matching creation rules found")
+var ErrSopsNoConfigMatch = errors.New("error loading config: no matching creation rules found")
 
 type RootCommand struct{}
 
@@ -48,7 +48,7 @@ func (s *sopsclient) File(filepath string, ext string) ([]byte, error) {
 
 func (s *sopsclient) IsFileMatchCreationRule(file string) (bool, error) {
 	c, err := sopsconf.LoadCreationRuleForFile(s.ConfPath, file, map[string]*string{})
-	if err != nil && err.Error() == SopsNoConfigMatch.Error() {
+	if err != nil && err.Error() == ErrSopsNoConfigMatch.Error() {
 		log.Debugf("File: %s doesn't match any sops config creation_rule regex. Skipping.\n", file)
 		return false, nil
 	}
@@ -94,7 +94,7 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 
 	if len(args) < 1 {
 		// Try to parse the change set from a pipe
-		input, err := ioutil.ReadAll(os.Stdin)
+		input, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return err
 		}
@@ -115,6 +115,11 @@ func (c *RootCommand) runE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	sops.ConfPath = confPath
+
+	if !sops.HasConf() {
+		log.Info("No sops config found, nothing to validate")
+		return nil
+	}
 
 	filteredFiles, err := getFilteredFiles(sops, files)
 	if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -9,13 +9,18 @@ import (
 )
 
 type decryptmock struct {
-	hasError bool
-	hasConf  bool
+	hasError    bool
+	hasConf     bool
+	errorString string
 }
 
 func (d *decryptmock) File(filepath string, ext string) ([]byte, error) {
 	if d.hasError {
-		return nil, errors.New("mock error")
+		msg := "mock error"
+		if d.errorString != "" {
+			msg = d.errorString
+		}
+		return nil, errors.New(msg)
 	}
 	return []byte("success"), nil
 }
@@ -100,26 +105,40 @@ func TestGetSopsConfig(t *testing.T) {
 
 func TestDecryptFiles(t *testing.T) {
 	tests := []struct {
-		hasError bool
+		name        string
+		hasError    bool
+		errorString string
+		wantErr     bool
 	}{
 		{
-			hasError: false,
+			name: "successful decryption",
 		},
 		{
+			name:     "decryption error",
 			hasError: true,
+			wantErr:  true,
+		},
+		{
+			name:        "sops metadata not found is an error",
+			hasError:    true,
+			errorString: "sops metadata not found",
+			wantErr:     true,
 		},
 	}
 
 	mock := &decryptmock{}
 
 	for _, test := range tests {
-		mock.hasError = test.hasError
-		err := decryptFiles(mock, []string{"1"})
-		if mock.hasError {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			mock.hasError = test.hasError
+			mock.errorString = test.errorString
+			err := decryptFiles(mock, []string{"1"})
+			if test.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
If a sops-precommit hook is run on a repository without sops configuration; it fails and tries to decrypt every yaml it finds.

This adjusts the behavior to only attempt decryption if a sops configuration has been loaded.

The PR also includes updates:
 - linting enforcement
 - go.mod 1.25 update